### PR TITLE
Reservoir Deployment Modules and e2e test script.

### DIFF
--- a/container/config/reservoir/db-initialize-k8s
+++ b/container/config/reservoir/db-initialize-k8s
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+. /reservoir/container/secrets/secrets.env
+
+echo "Initializing Reservoir DB."
+
+
+CONNECTION_URL="postgresql://${RESERVOIR_DB_USER}:${RESERVOIR_DB_PASSWORD}@${RESERVOIR_DB_HOST}:${RESERVOIR_DB_PORT}/${RESERVOIR_DB_NAME}"
+
+until psql ${CONNECTION_URL} -c '\l'; do
+  >&2 echo "Waiting for postgres, sleeping."
+  sleep 10s
+done
+
+echo "Activating hstore extension"
+set -x
+psql "${CONNECTION_URL}" -c "create extension hstore;"
+set +x
+
+echo "Making/Running database migrations."
+
+python3 /reservoir/manage.py makemigrations
+python3 /reservoir/manage.py migrate
+
+echo "Migrations complete."
+
+exit 0

--- a/container/config/reservoir/runmodwsgi-entrypoint.sh
+++ b/container/config/reservoir/runmodwsgi-entrypoint.sh
@@ -2,11 +2,15 @@
 
 echo "foo"
 
+. /reservoir/container/secrets/secrets.env
+
 function log {
     echo "[runmodwsgi entrypoint $(date)]: $1"
 }
 
 log "Changing permissions on fs mount."
+
+log "RESERVOIR_DEBUG: ${RESERVOIR_DEBUG}"
 
 chown -R :www-data /reservoir/models
 chmod -R a+wr /reservoir/models

--- a/container/config/reservoir/runmodwsgi-entrypoint.sh
+++ b/container/config/reservoir/runmodwsgi-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo "foo"
+
+function log {
+    echo "[runmodwsgi entrypoint $(date)]: $1"
+}
+
+log "Changing permissions on fs mount."
+
+chown -R :www-data /reservoir/models
+chmod -R a+wr /reservoir/models
+
+log "Checking permissions for /reservoir/models: $(ls -laF /reservoir/models)"
+
+log "Starting runmodwsgi process."
+
+cd /reservoir
+python manage.py runmodwsgi --port 80 --user=www-data --group=www-data \
+       --server-root=/etc/mod_wsgi-express-80 --error-log-format "%M" --log-to-terminal

--- a/k8s/cloudbuild-reservoir.yaml
+++ b/k8s/cloudbuild-reservoir.yaml
@@ -14,7 +14,7 @@
 
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/reservoir:$SHORT_SHA', '-t', 'gcr.io/$PROJECT_ID/reservoir:latest', '.']
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/reservoir:$SHORT_SHA', '.']
 images:
 - 'gcr.io/$PROJECT_ID/reservoir:$SHORT_SHA'
 timeout: 3600s

--- a/k8s/cloudbuild-reservoir.yaml
+++ b/k8s/cloudbuild-reservoir.yaml
@@ -14,7 +14,7 @@
 
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/reservoir:$SHORT_SHA', '.']
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/reservoir:$SHORT_SHA', '-t', 'gcr.io/$PROJECT_ID/reservoir:latest', '.']
 images:
 - 'gcr.io/$PROJECT_ID/reservoir:$SHORT_SHA'
 timeout: 3600s

--- a/k8s/ktest_reservoir.sh
+++ b/k8s/ktest_reservoir.sh
@@ -123,12 +123,16 @@ if ! reservoir_create_nas; then
 fi
 
 # Create the Persistent Volume and Persistent Volume Claim
-
 if ! reservoir_create_pvc; then
    LOG_INFO "Reservoir failed to create a PVC for the application to aquire the NAS."
    return 1
 fi
-   
+
+# Initialze the CloudSQL Database with extensions and Migrations.
+if ! reservoir_run_init_db_job; then
+  LOG_INFO "Failed to initialize cloudsql db."
+  return 1
+fi
 
 LOG_INFO "To clean up this test, run the following command: gcloud projects delete ${GCP_PROJECT_ID}"
 

--- a/k8s/ktest_reservoir.sh
+++ b/k8s/ktest_reservoir.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+#
+# Simple test script that will deploy Reservoir to a Kubernetes Cluster.
+#
+# Broken out as separate job from kbootstrap to facilitate rapid testing of the deployment of Reservoir
+# without the need to spin up the full Waybak suite of tools.
+#
+# Creates new project with random suffix and deploys all necessary reserouces to the cluster
+# Note you need to be a billing admin in the wybk.org organization to run this script.
+#
+
+current_script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# 1. Create a new project with random postfix
+LOG_INFO() {
+    echo "[ktest_reservoir INFO $(date +"%Y-%m-%d %T %Z")] $1"
+}
+
+function generate_random_suffix {
+  # Generates a random 16-character password that can be used as a bucket name suffix
+  local LENGTH="${1:-15}"
+  echo "b`(date ; dd if=/dev/urandom count=2 bs=1024) 2>/dev/null | md5sum | head -c ${LENGTH}`"
+}
+
+function cleanup {
+  gclout project delete "${GCP_PROJECT_ID}"
+}
+
+export GCP_POSTFIX="$(generate_random_suffix 5)"
+export WYBK_ORG_ID=344127236084
+export WYBK_BILLING_ID="01930B-854143-2F2F86"
+LOGFILE="/tmp/ktest_reservoir_${GCP_POSTFIX}.log"
+touch ${LOGFILE}
+export GCP_PROJECT_ID="waybak-test-$(generate_random_suffix 5)"
+export GCP_REGION=us-"east4"
+export GCP_ZONE="us-east4-a"
+export CLUSTER_NAME="test-cluster"
+export CLOUDBUILD_LOGS_BUCKET="gs://cloudbuild-logs-$(generate_random_suffix)"
+
+. ${current_script_dir}/functions.sh
+. ${current_script_dir}/reservoir_functions.sh
+
+(
+LOG_INFO "GCP_PROJECT_ID: ${GCP_PROJECT_ID}"
+LOG_INFO "CLUSTER_NAME: ${CLUSTER_NAME}"
+LOG_INFO "CLOUDBUILD_LOGS_BUCKET= ${CLOUDBUILD_LOGS_BUCKET}"
+
+# Clean and remake secrets file
+if [ -f ./container/secrets/secrets.env ]
+then
+  LOG_INFO "Deleting secrets file."
+  python3 ./makesecrets ~/waybak_secrets.env
+fi
+
+gcloud projects create "${GCP_PROJECT_ID}" --organization="${WYBK_ORG_ID}"
+
+if [ $? -ne 0 ]
+then
+  echo "Failed to create project ${GPC_PROJECT_ID}"
+  return 1
+fi
+
+gcloud config set project ${GCP_PROJECT_ID}
+gcloud config set compute/zone ${GCP_ZONE}
+
+# Need billing activated to enable apis
+gcloud beta billing projects link "${GCP_PROJECT_ID}" --billing-account "${WYBK_BILLING_ID}"
+
+set -x
+gcloud services enable cloudbuild.googleapis.com container.googleapis.com \
+  containerregistry.googleapis.com file.googleapis.com redis.googleapis.com \
+  servicenetworking.googleapis.com sql-component.googleapis.com sqladmin.googleapis.com \
+  storage-api.googleapis.com storage-component.googleapis.com vision.googleapis.com
+set +x
+
+
+
+if [ ! $(gsutil ls "${CLOUDBUILD_LOGS_BUCKET}") ]
+then
+  LOG_INFO "Creating cloud build logs bucket: ${CLOUDBUILD_LOGS_BUCKET}"
+  gsutil mb -p "${GCP_PROJECT_ID}" "${CLOUDBUILD_LOGS_BUCKET}"
+  if [ $? -ne 0 ]
+  then
+    LOG_INFO "FAILED TO CREATE BUCKET."
+    return 1
+  fi
+fi
+
+gcloud container clusters create ${CLUSTER_NAME}  --zone ${GCP_ZONE} \
+  --release-channel stable --enable-ip-alias --machine-type "n1-standard-4" --num-nodes=3
+
+# Necessary for database creation
+gcloud compute addresses create google-managed-services-default --global --purpose=VPC_PEERING --prefix-length=20 --network=default
+gcloud services vpc-peerings connect --service=servicenetworking.googleapis.com --network=default --ranges=google-managed-services-default
+
+# Create and configure the Postgres SQL Database w/ service accounts.
+if ! reservoir_create_db_instance;
+then
+  LOG_INFO "Failed to create Reservoir DB instance."
+  return 1
+fi
+
+if ! reservoir_create_cloudsql_service_account
+then
+  LOG_INFO "Failed to create Reservoir CloudSQL service account."
+  return 1
+fi
+
+clone_reservoir
+
+# Run cloud build
+if ! reservoir_cloud_build
+then
+  LOG_INFO "Reservoir Cloudbuild failed."
+  return 1
+fi
+
+
+# Create the NAS        
+if ! reservoir_create_nas
+then
+  LOG_INFO "Reservoir failed to create network mapped storage."
+  return 1
+fi
+
+# Create the Persistent Volume and Persistent Volume Claim
+
+if ! reservoir_create_pvc
+   LOG_INFO "Reservoir failed to create a PVC for the application to aquire the NAS."
+   return 1
+fi
+   
+
+
+LOG_INFO "To clean up this test, run the following command: gcloud projects delete ${GCP_PROJECT_ID}"
+
+) 2>&1 | tee "${LOGFILE}"
+
+
+
+
+
+

--- a/k8s/ktest_reservoir.sh
+++ b/k8s/ktest_reservoir.sh
@@ -134,6 +134,20 @@ if ! reservoir_run_init_db_job; then
   return 1
 fi
 
+# Push an external loadbalancer for debugging
+if ! reservoir_start_external_service; then
+  LOG_INFO "Failed to start externally available service."
+  return 1
+else
+  LOG_INFO "Service available at external ip: $(kubectl get services)"
+fi
+
+# Pushing debug deployment
+if ! reservoir_deploy_debug; then
+  LOG_INFO "Failed to push deployment."
+  return 1
+fi
+
 LOG_INFO "To clean up this test, run the following command: gcloud projects delete ${GCP_PROJECT_ID}"
 
 ) 2>&1 | tee "${LOGFILE}"

--- a/k8s/reservoir-db-migration-job.yaml.in
+++ b/k8s/reservoir-db-migration-job.yaml.in
@@ -24,9 +24,9 @@ spec:
     spec:
       restartPolicy: Never
       volumes:
-        - name: reservoir-sa-vm
+        - name: reservoir-sa-key-vlm
           secret:
-            secretName: reservoir-sa
+            secretName: reservoir-sa-key
       containers:
         # [Start Reservoir DB Migration Job]
         - name: reservoir-db-migration
@@ -39,7 +39,7 @@ spec:
         - name: cloud-sql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:latest
           volumeMounts:
-          - name: reservoir-sa-vm
+          - name: reservoir-sa-key-vlm
             mountPath: /secrets/
             readOnly: true
           command:

--- a/k8s/reservoir-deployment.yaml.in
+++ b/k8s/reservoir-deployment.yaml.in
@@ -42,7 +42,7 @@ spec:
             containerPort: 443
         env:
         - name: RESERVOIR_DEBUG
-          value: "False"
+          value: "${RESERVOIR_DEBUG}"
         - name: RESERVOIR_LOG_LEVEL
           value: "DEBUG"
       # [End main H3DMR appliction]

--- a/k8s/reservoir-deployment.yaml.in
+++ b/k8s/reservoir-deployment.yaml.in
@@ -1,0 +1,65 @@
+# [Start Reservoir Deployment]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reservoir
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: reservoir
+  template:
+    metadata:
+      name: reservoir
+      labels:
+        app: reservoir
+    spec:
+      volumes:
+      - name: reservoir-sa-key-vlm
+        secret:
+          secretName: reservoir-sa-key
+      - name: reservoir-model-vlm
+        persistentVolumeClaim:
+          claimName: reservoir-fileserver-claim
+          readOnly: false
+      containers:
+      # [Start main Reservoir application]
+      - name: reservoir
+        image: gcr.io/${GCP_PROJECT_ID}/reservoir:latest # make the version an argument
+        imagePullPolicy: Always # Always pull the image from the repo.
+        # securityContext:
+        #   runAsUser: 1001 # To mount reservoirfs as GID 1001
+        volumeMounts:
+        - mountPath: /reservoir/models
+          name: reservoir-model-vlm
+        command:
+          - "/reservoir/container/config/reservoir/runmodwsgi-entrypoint.sh"
+        ports:
+          - name: http
+            containerPort: 80
+          - name: https
+            containerPort: 443
+        env:
+        - name: RESERVOIR_DEBUG
+          value: "False"
+        - name: RESERVOIR_LOG_LEVEL
+          value: "DEBUG"
+      # [End main H3DMR appliction]
+      # [Start CloudSQL Proxy Sidecar]
+      - name: cloud-sql-proxy
+        image: gcr.io/cloudsql-docker/gce-proxy:latest
+        volumeMounts:
+        - name: reservoir-sa-key-vlm
+          mountPath: /secrets/
+          readOnly: true
+        command:
+          - "/cloud_sql_proxy"
+          - "-instances=${RESERVOIR_DB_INSTANCE_CONNECTION_NAME}"
+          - "-credential_file=/secrets/service_account.json"
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
+       # [End CloudSQL Proxy Sidecar]
+# [End Reservoir Deployment]

--- a/k8s/reservoir-service-external.yaml.in
+++ b/k8s/reservoir-service-external.yaml.in
@@ -1,0 +1,38 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Start an external load balancer for the Reservoir application.
+# This is useful for e2e testing of Reservoir in isoloation of the FE.
+# Prefer the internal load balancer with FE proxy in production.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: reservoir-external
+  labels:
+    app: reservoir-external
+spec:
+  type: LoadBalancer
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https
+    - name: debug
+      port: 8080
+      targetPort: debug
+  selector:
+    app: reservoir

--- a/k8s/reservoir-service.yaml.in
+++ b/k8s/reservoir-service.yaml.in
@@ -1,0 +1,39 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Start an internal load balancer for the Reservoir application.
+# The FE/Proxy will forward requests to this internal only service.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: reservoir
+  annotations:
+    cloud.google.com/load-balancer-type: "Internal"
+  labels:
+    app: reservoir
+spec:
+  type: LoadBalancer
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https
+    - name: debug
+      port: 8080
+      targetPort: debug
+  selector:
+    app: reservoir

--- a/k8s/reservoir_functions.sh
+++ b/k8s/reservoir_functions.sh
@@ -219,7 +219,7 @@ function reservoir_create_db_instance {
   gcloud beta sql users create "${RESERVOIR_DB_USER}" --instance="${RESERVOIR_DB_INSTANCE}" "--password=${RESERVOIR_DB_PASSWORD}"
 }
 
-reservoir_run_init_db_job {
+function reservoir_run_init_db_job {
   local script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
   set -x
   ${script_dir}/kapply k8s/reservoir-db-migration-job.yaml.in
@@ -228,6 +228,8 @@ reservoir_run_init_db_job {
   # Give the migration time to complete
   LOG_INFO "Waiting one minute for migrations to complete."
   sleep 60s
+
+  kubectl logs -l name=reservoir-db-migration
 
   LOG_INFO "To delete db init job run: kubectl delete jobs reservoir-db-migration"
 }

--- a/k8s/reservoir_functions.sh
+++ b/k8s/reservoir_functions.sh
@@ -233,3 +233,17 @@ function reservoir_run_init_db_job {
 
   LOG_INFO "To delete db init job run: kubectl delete jobs reservoir-db-migration"
 }
+
+function reservoir_start_internal_service {
+  LOG_INFO "Starting Reservoir internal Load Balancer."
+
+  local script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+  set -x
+  ${script_dir}/kapply k8s/reservoir-db-migration-job.yaml.in
+  set +x
+
+  # Give the service a few seconds to start
+  sleep 30s
+
+  kubectl get services
+}

--- a/k8s/reservoir_functions.sh
+++ b/k8s/reservoir_functions.sh
@@ -247,3 +247,17 @@ function reservoir_start_internal_service {
 
   kubectl get services
 }
+
+function reservoir_deploy_debug {
+  add_secret ${secrets_env_file} RESERVOIR_DEBUG "True"
+
+  local script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+  ${script_dir}/kapply k8s/reservoir-deployment.yaml.in
+}
+
+function reservoir_deploy_prod {
+  add_secrete ${secrets_env_file} RESERVOIR_DEBUG "False"
+  
+  local script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+  ${script_dir}/kapply k8s/reservoir-deployment.yaml.in
+}


### PR DESCRIPTION
Run an e2e test for the Reservoir component by running the following command within the Project folder:

. ./k8s/kteset_reservoir.sh

This script will:

1. Create a new GCP project with random suffix
2. Enable all necessary cloud services for Reservoir
3. Create a kubernetes cluster
4. Create the necessary service accounts, access key and push the key to as a k8 secret
5. Create a CloudSQL Postgres database
6. Initialize the db's extensions and perform migrations
7. Spin up the Reservoir application
8. Create an externally available load balancer service for debugging the application
9. Print out a command for the client to delete the test project when finished
