### PR TITLE
extend tegola initial delay before readiness check to 120 secs

### DIFF
--- a/k8s/tegola-deployment.yaml.in
+++ b/k8s/tegola-deployment.yaml.in
@@ -49,13 +49,13 @@ spec:
           livenessProbe:
             tcpSocket:
               port: 8088
-            initialDelaySeconds: 8
+            initialDelaySeconds: 120
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /
               port: 8088
-            initialDelaySeconds: 10
+            initialDelaySeconds: 120
             periodSeconds: 10
             timeoutSeconds: 5
           volumeMounts:


### PR DESCRIPTION
The tegola pod seems to take a long time to start up; hopefully this will eliminate the multiple pod restarts that have been happening on startup.